### PR TITLE
Migrate GitHub Stats and Top Langs cards to github-stats-extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <summary>💻 Profile</summary>
     <br/>
 
-| [![Jadhiel Vélez's GitHub Stats](https://github-readme-stats.vercel.app/api?username=jadhielv&show_icons=true&text_color=f8f8f2&hide_title=true&theme=github_dark)](https://github.com/anuraghazra/github-readme-stats)	| [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=jadhielv&layout=compact&text_color=f8f8f2&langs_count=8&hide_title=true&theme=github_dark)](https://github.com/anuraghazra/github-readme-stats)	|
+| [![Jadhiel Vélez's GitHub Stats](https://github-stats-extended.vercel.app/api?username=jadhielv&show_icons=true&text_color=f8f8f2&theme=github_dark&show=prs_merged_percentage,prs_reviewed&rank_icon=github&custom_title=Jadhiel%20V%C3%A9lez%27s%20GitHub%20Stats)](https://github.com/stats-organization/github-stats-extended)	| [![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=jadhielv&layout=compact&text_color=f8f8f2&langs_count=8&hide_title=true&theme=github_dark)](https://github.com/stats-organization/github-stats-extended)	|
 |---	                                                                                                                  |---
 
 ***NOTE**: Top languages do not indicate my skill level or something like that, it's a GitHub metric of which languages I've the most code.*

--- a/README.template.md
+++ b/README.template.md
@@ -19,7 +19,7 @@
     <summary>💻 Profile</summary>
     <br/>
 
-| [![Jadhiel Vélez's GitHub Stats](https://github-readme-stats.vercel.app/api?username=jadhielv&show_icons=true&text_color=f8f8f2&hide_title=true&theme=github_dark)](https://github.com/anuraghazra/github-readme-stats)	| [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=jadhielv&layout=compact&text_color=f8f8f2&langs_count=8&hide_title=true&theme=github_dark)](https://github.com/anuraghazra/github-readme-stats)	|
+| [![Jadhiel Vélez's GitHub Stats](https://github-stats-extended.vercel.app/api?username=jadhielv&show_icons=true&text_color=f8f8f2&theme=github_dark&show=prs_merged_percentage,prs_reviewed&rank_icon=github&custom_title=Jadhiel%20V%C3%A9lez%27s%20GitHub%20Stats)](https://github.com/stats-organization/github-stats-extended)	| [![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=jadhielv&layout=compact&text_color=f8f8f2&langs_count=8&hide_title=true&theme=github_dark)](https://github.com/stats-organization/github-stats-extended)	|
 |---	                                                                                                                  |---
 
 ***NOTE**: Top languages do not indicate my skill level or something like that, it's a GitHub metric of which languages I've the most code.*


### PR DESCRIPTION
This change completes the migration of the profile's GitHub Stats and Top Langs cards from the unmaintained github-readme-stats to the successor project github-stats-extended. It also configures the card design with custom title, GitHub rank icon, and extended PR metrics to match the user's attachment.

---
*PR created automatically by Jules for task [8589221890358997155](https://jules.google.com/task/8589221890358997155) started by @Jadhielv*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated profile statistics widgets to use the extended GitHub stats provider.
  * Added merged and reviewed pull request metrics to the main statistics card.
  * Preserved the existing profile dashboard layout and badge links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->